### PR TITLE
fixup! add vendor.google.aam.IAam to framework compatibility matrix

### DIFF
--- a/location/gnssd/device_framework_matrix_product.xml
+++ b/location/gnssd/device_framework_matrix_product.xml
@@ -7,13 +7,4 @@
             <instance>vendor</instance>
         </interface>
     </hal>
-
-    <hal format="aidl">
-        <name>vendor.google.aam</name>
-        <version>2</version>
-        <interface>
-            <name>IAam</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
 </compatibility-matrix>

--- a/location/gnssd/pixel_gnss_hal.mk
+++ b/location/gnssd/pixel_gnss_hal.mk
@@ -10,3 +10,5 @@ PRODUCT_VENDOR_PROPERTIES += \
 # Compatibility matrix
 DEVICE_PRODUCT_COMPATIBILITY_MATRIX_FILE += \
     device/google/akita/location/gnssd/device_framework_matrix_product.xml
+
+DEVICE_PRODUCT_COMPATIBILITY_MATRIX_FILE += device/google/gs-common/proprietary/vendor.google.aam.xml


### PR DESCRIPTION
Depends on https://github.com/GrapheneOS/device_google_gs-common/pull/7