### PR TITLE
fix incorrect inclusion directive for GosAkitaOverlay

### DIFF
--- a/device-akita.mk
+++ b/device-akita.mk
@@ -32,7 +32,7 @@ $(call inherit-product-if-exists, vendor/google_devices/akita/proprietary/akita/
 $(call inherit-product-if-exists, vendor/google_devices/akita/proprietary/device-vendor.mk)
 $(call inherit-product-if-exists, vendor/google_devices/akita/proprietary/WallpapersAkita.mk)
 
-DEVICE_PACKAGES += GosAkitaOverlay
+PRODUCT_PACKAGES += GosAkitaOverlay
 
 ifeq ($(RELEASE_PIXEL_AIDL_AUDIO_HAL_ZUMA),true)
 USE_AUDIO_HAL_AIDL := true


### PR DESCRIPTION
GosAkitaOverlay package overrides the `config_gnssPsdsType` value from `broadcom` (set in zuma repo) to `samsung`.